### PR TITLE
Package cleanup and additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: go
 go:
   - 1.6
+  - 1.7

--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 [![Build Status](https://travis-ci.org/brianfoshee/s3upload.png)](https://travis-ci.org/brianfoshee/s3upload)
 
-// TODO: make this nicer
+Package s3upload signs S3 POST policy documents for browser-based file uploads
+to AWS S3.
+More details on that can be found in the [AWS docs][docs].
 
-Zero external dependencies. Uses ___ this signature method to sign policies.
+### Usage
 
-To use this, generate a JSON policy based off the S3Policy struct (probably using
-html/template - see example for details). Then pass that policy into some func to
-have it spit out the signed policy and signature.
-POlicy details here http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+To use this package, generate a POST policy document, then pass that policy into
+the Sign method to receive a signature to be used in a POST form.
 
-// TODO: mention the examples
-// TODO: add readme for the examples
-// TODO: clean up examples
+Details on
+Policy details here http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+
+See the examples folder for complete usage.
+
+### Signature details
+
+The policy document is signed using this calculation:
+
+[![Signature Calculation](http://docs.aws.amazon.com/AmazonS3/latest/API/images/sigV4-post.png)](http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html#sigv4-post-signature-calc)
+
+[docs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 [![Build Status](https://travis-ci.org/brianfoshee/s3upload.png)](https://travis-ci.org/brianfoshee/s3upload)
 
-Package s3upload signs S3 POST policy documents for browser-based file uploads
-to AWS S3.
-More details on that can be found in the [AWS docs][docs].
+Package s3upload signs POST policy documents for browser-based file uploads
+to AWS S3. More details on browser-based file uploads can be found in the
+[AWS docs][docs].
 
 ### Usage
 
-To use this package, generate a POST policy document, then pass that policy into
+To use this package, generate a POST policy document then pass that policy into
 the Sign method to receive a signature to be used in a POST form.
 
 Details on Policy documents can be found in the [AWS docs][pdocs].
 
 The [policy][policy] package can be used to generate these documents if
 necessary.
+
+```go
+su := s3upload.New("us-east-1", secret)
+encoded, signed := su.Sign(policyBytes)
+```
 
 See the examples folder for complete usage.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 [![Build Status](https://travis-ci.org/brianfoshee/s3upload.png)](https://travis-ci.org/brianfoshee/s3upload)
 
+// TODO: make this nicer
+
+Zero external dependencies. Uses ___ this signature method to sign policies.
+
 To use this, generate a JSON policy based off the S3Policy struct (probably using
 html/template - see example for details). Then pass that policy into some func to
 have it spit out the signed policy and signature.
 POlicy details here http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
 
-The tests get their info from this AWS example, those aren't my S3 credentials:
-http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+// TODO: mention the examples
+// TODO: add readme for the examples
+// TODO: clean up examples

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ The policy document is signed using this calculation:
 
 [docs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html
 [pdocs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
-[policy]: https://github.com/brianfoshee/tree/master/policy
+[policy]: https://github.com/brianfoshee/s3upload/tree/master/policy

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ More details on that can be found in the [AWS docs][docs].
 To use this package, generate a POST policy document, then pass that policy into
 the Sign method to receive a signature to be used in a POST form.
 
-Details on
-Policy details here http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+Details on Policy documents can be found in the [AWS docs][pdocs].
+
+The [policy][policy] package can be used to generate these documents if
+necessary.
 
 See the examples folder for complete usage.
 
@@ -21,3 +23,5 @@ The policy document is signed using this calculation:
 [![Signature Calculation](http://docs.aws.amazon.com/AmazonS3/latest/API/images/sigV4-post.png)](http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html#sigv4-post-signature-calc)
 
 [docs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html
+[pdocs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+[policy]: https://github.com/brianfoshee/tree/master/policy

--- a/examples/gen-policy/main.go
+++ b/examples/gen-policy/main.go
@@ -19,7 +19,7 @@ func main() {
 	p.SetCondition(policy.ConditionBucket, "johnsmith", policy.ConditionMatchExact)
 	p.SetCondition(policy.ConditionKey, "user/eric/", policy.ConditionMatchStartsWith)
 
-	// Serialize the policy as a JSON document (as expetect by AWS S3).
+	// Serialize the policy as a JSON document (as expected by AWS S3).
 	b, err := json.Marshal(p)
 	if err != nil {
 		fmt.Println("Issue marshaling policy")

--- a/examples/gen-policy/main.go
+++ b/examples/gen-policy/main.go
@@ -15,9 +15,9 @@ func main() {
 	p := policy.Policy{
 		Expiration: time.Date(2007, 12, 01, 12, 0, 0, 0, time.UTC),
 	}
-	p.SetCondition(policy.ConditionKeyACL, "public-read", policy.ConditionMatchExact)
-	p.SetCondition(policy.ConditionKeyBucket, "johnsmith", policy.ConditionMatchExact)
-	p.SetCondition(policy.ConditionKeyKey, "user/eric/", policy.ConditionMatchStartsWith)
+	p.SetCondition(policy.ConditionACL, "public-read", policy.ConditionMatchExact)
+	p.SetCondition(policy.ConditionBucket, "johnsmith", policy.ConditionMatchExact)
+	p.SetCondition(policy.ConditionKey, "user/eric/", policy.ConditionMatchStartsWith)
 
 	// Serialize the policy as a JSON document (as expetect by AWS S3).
 	b, err := json.Marshal(p)

--- a/examples/gen-policy/main.go
+++ b/examples/gen-policy/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/brianfoshee/s3upload"
+	"github.com/brianfoshee/s3upload/policy"
+)
+
+func main() {
+	// Create the policy
+	p := policy.Policy{
+		Expiration: time.Date(2007, 12, 01, 12, 0, 0, 0, time.UTC),
+	}
+	p.SetCondition(policy.ConditionKeyACL, "public-read", policy.ConditionMatchExact)
+	p.SetCondition(policy.ConditionKeyBucket, "johnsmith", policy.ConditionMatchExact)
+	p.SetCondition(policy.ConditionKeyKey, "user/eric/", policy.ConditionMatchStartsWith)
+
+	// Serialize the policy as a JSON document (as expetect by AWS S3).
+	b, err := json.Marshal(p)
+	if err != nil {
+		fmt.Println("Issue marshaling policy")
+	}
+
+	s := s3upload.New("us-east-1", os.Getenv("AWS_SECRET_KEY_ID"))
+	// pass the policy into the AWS signing algorithm
+	encodedPolicy, signature := s.Sign(b)
+
+	// Use the signedPolicy and signature in a form for uploading.
+	// See examples/supply-policy for a complete html rendered form.
+	fmt.Println(encodedPolicy)
+	fmt.Println(signature)
+
+}

--- a/examples/poc/main.go
+++ b/examples/poc/main.go
@@ -75,11 +75,11 @@ func main() {
 		}
 
 		// generate signature and policy
-		signed := su.Sign(buf.Bytes())
+		policy, signed := su.Sign(buf.Bytes())
 
 		f := Form{
-			Policy:    string(signed.Policy),
-			Signature: string(signed.Signature),
+			Policy:    policy,
+			Signature: signed,
 			URL:       "https://" + bucket + ".s3.amazonaws.com/",
 			Payload:   p,
 		}

--- a/examples/supply-policy/main.go
+++ b/examples/supply-policy/main.go
@@ -36,7 +36,8 @@ type Form struct {
 
 func main() {
 	// be sure to fill out the AWS secret, key, and bucket
-	su := s3upload.New("us-east-1", "")
+	secret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	su := s3upload.New("us-east-1", secret)
 	key := os.Getenv("AWS_ACCESS_KEY_ID")
 	bucket := "brianfoshee"
 

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,39 @@
+Package policy provides functionlity to create a POST policy for uploading a
+file directly from a browser to S3.
+
+More details for creating a policy can be found in [Amazon's docs][docs].
+
+### Usage
+
+Here's how to create the following Policy document (taken from the AWS docs).
+
+```json
+{ "expiration": "2007-12-01T12:00:00.000Z",
+  "conditions": [
+    {"acl": "public-read" },
+    {"bucket": "johnsmith" },
+    ["starts-with", "$key", "user/eric/"],
+  ]
+}
+```
+
+```go
+p := policy.Policy{
+	Expiration: time.Date(2007, 12, 01, 12, 0, 0, 0, time.UTC),
+}
+p.SetCondition(policy.ConditionKeyACL, "public-read", policy.ConditionMatchExact)
+p.SetCondition(policy.ConditionKeyBucket, "johnsmith", policy.ConditionMatchExact)
+p.SetCondition(policy.ConditionKeyKey, "user/eric/", policy.ConditionStartsWith)
+b, err := json.Marshal(p)
+// handle err
+
+// sign the policy
+s := s3upload.New("", "")
+enc, signed := s.Sign(b)
+
+```
+
+See the examples folder for an end-to-end demonstration of rendering a form to
+be used for uploading.
+
+[docs]: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -7,6 +7,44 @@ import (
 	"time"
 )
 
+// Although you must specify one condition for each form field that you specify
+// in the form, you can create more complex matching criteria by specifying
+// multiple conditions for a form field.
+type ConditionMatch int
+
+const (
+	ConditionMatchExact ConditionMatch = iota
+	ConditionMatchStartsWith
+	ConditionMatchAny
+	ConditionMatchRange
+)
+
+const AWSV4SignatureAlgorithm = "AWS4-HMAC-SHA256"
+
+type ConditionKey string
+
+// conditions supported by default. See AWS docs for rules when using each.
+// TODO Document Support x-amz-meta-*
+// TODO Document support x-amz-*
+const (
+	ConditionKeyACL                   ConditionKey = "acl"
+	ConditionKeyBucket                             = "bucket"
+	ConditionKeyContentLengthRange                 = "content-length-range"
+	ConditionKeyCacheControl                       = "Cache-Control"
+	ConditionKeyContentType                        = "Content-Type"
+	ConditionKeyContentDisposition                 = "Content-Disposition"
+	ConditionKeyContentEncoding                    = "Content-Encoding"
+	ConditionKeyExpires                            = "Expires"
+	ConditionKeyKey                                = "key"
+	ConditionKeySuccessActionRedirect              = "success_action_redirect"
+	ConditionKeyRedirect                           = "redirect"
+	ConditionKeySuccessActionStatus                = "success_action_status"
+	ConditionKeyAMZAlgorithm                       = "x-amz-algorithm"
+	ConditionKeyAMZCredential                      = "x-amz-credential"
+	ConditionKeyAMZDate                            = "x-amz-date"
+	ConditionKeyAMZSecurityToken                   = "x-amz-security-token"
+)
+
 type Policy struct {
 	Expiration time.Time
 	conditions []condition
@@ -26,6 +64,14 @@ func (p *Policy) SetRangeCondition(k ConditionKey, l, u uint64) {
 		match:      ConditionMatchRange,
 	}
 	p.conditions = append(p.conditions, c)
+}
+
+func (p Policy) String() string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
 }
 
 // I want to avoid this but how?
@@ -88,50 +134,3 @@ func (c condition) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(a)
 }
-
-// Although you must specify one condition for each form field that you specify
-// in the form, you can create more complex matching criteria by specifying
-// multiple conditions for a form field.
-type ConditionMatch int
-
-const (
-	ConditionMatchExact ConditionMatch = iota
-	ConditionMatchStartsWith
-	ConditionMatchAny
-	ConditionMatchRange
-)
-
-const AWSV4SignatureAlgorithm = "AWS4-HMAC-SHA256"
-
-type ConditionKey string
-
-// conditions supported by default. See AWS docs for rules when using each.
-// TODO Document Support x-amz-meta-*
-// TODO Document support x-amz-*
-const (
-	ConditionKeyACL                   ConditionKey = "acl"
-	ConditionKeyBucket                             = "bucket"
-	ConditionKeyContentLengthRange                 = "content-length-range"
-	ConditionKeyCacheControl                       = "Cache-Control"
-	ConditionKeyContentType                        = "Content-Type"
-	ConditionKeyContentDisposition                 = "Content-Disposition"
-	ConditionKeyContentEncoding                    = "Content-Encoding"
-	ConditionKeyExpires                            = "Expires"
-	ConditionKeyKey                                = "key"
-	ConditionKeySuccessActionRedirect              = "success_action_redirect"
-	ConditionKeyRedirect                           = "redirect"
-	ConditionKeySuccessActionStatus                = "success_action_status"
-
-	// For AWS Signature Version 4, the value is AWS4-HMAC-SHA256.
-	ConditionKeyAMZAlgorithm = "x-amz-algorithm"
-
-	// It is a string of the following form:
-	// <your-access-key-id>/<date>/<aws-region>/<aws-service>/aws4_request
-	ConditionKeyAMZCredential = "x-amz-credential"
-
-	// The date value specified in the ISO8601 formatted string.
-	ConditionKeyAMZDate = "x-amz-date"
-
-	// Amazon DevPay security token.
-	ConditionKeyAMZSecurityToken = "x-amz-security-token"
-)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -8,42 +8,53 @@ import (
 	"time"
 )
 
-// AWSV4SignatureALgorithm is the value typically used for the x-amz-algorithm
+// AWSV4SignatureAlgorithm is the value typically used for the x-amz-algorithm
 // condition key.
 const AWSV4SignatureAlgorithm = "AWS4-HMAC-SHA256"
 
-//
+// ConditionMatch can be one of the four condition matching types that can be
+// used in a POST policy.
 type ConditionMatch int
 
 const (
+	// ConditionMatchExact is to be used when a condition must match the
+	// exact value specified. Output ex: `{"acl": "public-read" }`.
 	ConditionMatchExact ConditionMatch = iota
+
+	// ConditionMatchStartsWith is to be used when a condition must start with
+	// the specified value. Output Ex: `["starts-with", "$key", "user/user1/"]`
 	ConditionMatchStartsWith
+
+	// ConditionMatchAny allows a form field to accept any value. Output ex:
+	// `["starts-with", "$success_action_redirect", ""]`.
 	ConditionMatchAny
+
+	// ConditionMatchRange is to be used when a form field must accept a range
+	// of values. Output ex: `["content-length-range", 1048579, 10485760]`.
 	ConditionMatchRange
 )
 
-type ConditionKey string
-
-// conditions supported by default. See AWS docs for rules when using each.
-// TODO Document Support x-amz-meta-*
-// TODO Document support x-amz-*
+// Condition elements supported by default. See AWS docs for rules when using
+// each.
+// If you need to use x-amz-meta-* or x-amz-* condition elements you can pass
+// those as strings to SetCondition.
 const (
-	ConditionKeyACL                   ConditionKey = "acl"
-	ConditionKeyBucket                             = "bucket"
-	ConditionKeyContentLengthRange                 = "content-length-range"
-	ConditionKeyCacheControl                       = "Cache-Control"
-	ConditionKeyContentType                        = "Content-Type"
-	ConditionKeyContentDisposition                 = "Content-Disposition"
-	ConditionKeyContentEncoding                    = "Content-Encoding"
-	ConditionKeyExpires                            = "Expires"
-	ConditionKeyKey                                = "key"
-	ConditionKeySuccessActionRedirect              = "success_action_redirect"
-	ConditionKeyRedirect                           = "redirect"
-	ConditionKeySuccessActionStatus                = "success_action_status"
-	ConditionKeyAMZAlgorithm                       = "x-amz-algorithm"
-	ConditionKeyAMZCredential                      = "x-amz-credential"
-	ConditionKeyAMZDate                            = "x-amz-date"
-	ConditionKeyAMZSecurityToken                   = "x-amz-security-token"
+	ConditionACL                   string = "acl"
+	ConditionBucket                       = "bucket"
+	ConditionContentLengthRange           = "content-length-range"
+	ConditionCacheControl                 = "Cache-Control"
+	ConditionContentType                  = "Content-Type"
+	ConditionContentDisposition           = "Content-Disposition"
+	ConditionContentEncoding              = "Content-Encoding"
+	ConditionExpires                      = "Expires"
+	ConditionKey                          = "key"
+	ConditionSuccessActionRedirect        = "success_action_redirect"
+	ConditionRedirect                     = "redirect"
+	ConditionSuccessActionStatus          = "success_action_status"
+	ConditionAMZAlgorithm                 = "x-amz-algorithm"
+	ConditionAMZCredential                = "x-amz-credential"
+	ConditionAMZDate                      = "x-amz-date"
+	ConditionAMZSecurityToken             = "x-amz-security-token"
 )
 
 // Policy represents an AWS POST policy.
@@ -65,14 +76,14 @@ type Policy struct {
 // multiple conditions for a form field.
 //
 // ConditionMatchRange cannot be used in here. Use SetRangeCondition for that.
-func (p *Policy) SetCondition(k ConditionKey, v string, m ConditionMatch) {
+func (p *Policy) SetCondition(k, v string, m ConditionMatch) {
 	c := condition{key: k, value: v, match: m}
 	p.conditions = append(p.conditions, c)
 }
 
 // SetRangeCondition adds a POST policy condition requiring a range of numbers
 // to the policy. This is only used for ConditionMatchRange.
-func (p *Policy) SetRangeCondition(k ConditionKey, l, u uint64) {
+func (p *Policy) SetRangeCondition(k string, l, u uint64) {
 	c := condition{
 		key:        k,
 		rangeLower: l,
@@ -99,11 +110,12 @@ func (p Policy) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d)
 }
 
+// condition holds an object which is used to validate a POST request.
 // Each form field that you specify in a form (except x-amz-signature, file,
 // policy, and field names that have an x-ignore- prefix) must appear in the
 // list of conditions.
 type condition struct {
-	key        ConditionKey
+	key        string
 	value      string
 	rangeLower uint64
 	rangeUpper uint64
@@ -117,7 +129,7 @@ func (c condition) MarshalJSON() ([]byte, error) {
 	// {"acl": "public-read" }
 	if c.match == ConditionMatchExact {
 		m := map[string]string{
-			string(c.key): c.value,
+			c.key: c.value,
 		}
 		return json.Marshal(m)
 	}
@@ -129,18 +141,18 @@ func (c condition) MarshalJSON() ([]byte, error) {
 		// Starts With:
 		// ["starts-with", "$key", "user/user1/"]
 		a[0] = "starts-with"
-		a[1] = "$" + string(c.key)
+		a[1] = "$" + c.key
 		a[2] = c.value
 	} else if c.match == ConditionMatchAny {
 		// Matching Any Content
 		// ["starts-with", "$success_action_redirect", ""]
 		a[0] = "starts-with"
-		a[1] = "$" + string(c.key)
+		a[1] = "$" + c.key
 		a[2] = ""
 	} else if c.match == ConditionMatchRange {
 		// Specifying Ranges
 		// ["content-length-range", 1048579, 10485760]
-		a[0] = string(c.key)
+		a[0] = c.key
 		a[1] = strconv.FormatUint(c.rangeLower, 10)
 		a[2] = strconv.FormatUint(c.rangeUpper, 10)
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,0 +1,137 @@
+// http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
+package policy
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+type Policy struct {
+	Expiration time.Time
+	conditions []condition
+}
+
+// Cannot use ConditionMatchRange in here. Use SetRangeCondition for that.
+func (p *Policy) SetCondition(k ConditionKey, v string, m ConditionMatch) {
+	c := condition{key: k, value: v, match: m}
+	p.conditions = append(p.conditions, c)
+}
+
+func (p *Policy) SetRangeCondition(k ConditionKey, l, u uint64) {
+	c := condition{
+		key:        k,
+		rangeLower: l,
+		rangeUpper: u,
+		match:      ConditionMatchRange,
+	}
+	p.conditions = append(p.conditions, c)
+}
+
+// I want to avoid this but how?
+type policyJSON struct {
+	Expiration string      `json:"expiration"`
+	Conditions []condition `json:"conditions"`
+}
+
+func (p Policy) MarshalJSON() ([]byte, error) {
+	d := policyJSON{
+		p.Expiration.Format("2006-01-02T15:04:05.000Z"),
+		p.conditions,
+	}
+	return json.Marshal(d)
+}
+
+// Each form field that you specify in a form (except x-amz-signature, file,
+// policy, and field names that have an x-ignore- prefix) must appear in the
+// list of conditions.
+type condition struct {
+	key        ConditionKey
+	value      string
+	rangeLower uint64
+	rangeUpper uint64
+	match      ConditionMatch
+}
+
+func (c condition) MarshalJSON() ([]byte, error) {
+	// Exact Matches:
+	// {"acl": "public-read" }
+	if c.match == ConditionMatchExact {
+		m := map[string]string{
+			string(c.key): c.value,
+		}
+		return json.Marshal(m)
+	}
+
+	// The other match types are arrays with 3 elements.
+	var a [3]string
+
+	if c.match == ConditionMatchStartsWith {
+		// Starts With:
+		// ["starts-with", "$key", "user/user1/"]
+		a[0] = "starts-with"
+		a[1] = "$" + string(c.key)
+		a[2] = c.value
+	} else if c.match == ConditionMatchAny {
+		// Matching Any Content
+		// ["starts-with", "$success_action_redirect", ""]
+		a[0] = "starts-with"
+		a[1] = "$" + string(c.key)
+		a[2] = ""
+	} else if c.match == ConditionMatchRange {
+		// Specifying Ranges
+		// ["content-length-range", 1048579, 10485760]
+		a[0] = string(c.key)
+		a[1] = strconv.FormatUint(c.rangeLower, 10)
+		a[2] = strconv.FormatUint(c.rangeUpper, 10)
+	}
+
+	return json.Marshal(a)
+}
+
+// Although you must specify one condition for each form field that you specify
+// in the form, you can create more complex matching criteria by specifying
+// multiple conditions for a form field.
+type ConditionMatch int
+
+const (
+	ConditionMatchExact ConditionMatch = iota
+	ConditionMatchStartsWith
+	ConditionMatchAny
+	ConditionMatchRange
+)
+
+const AWSV4SignatureAlgorithm = "AWS4-HMAC-SHA256"
+
+type ConditionKey string
+
+// conditions supported by default. See AWS docs for rules when using each.
+// TODO Document Support x-amz-meta-*
+// TODO Document support x-amz-*
+const (
+	ConditionKeyACL                   ConditionKey = "acl"
+	ConditionKeyBucket                             = "bucket"
+	ConditionKeyContentLengthRange                 = "content-length-range"
+	ConditionKeyCacheControl                       = "Cache-Control"
+	ConditionKeyContentType                        = "Content-Type"
+	ConditionKeyContentDisposition                 = "Content-Disposition"
+	ConditionKeyContentEncoding                    = "Content-Encoding"
+	ConditionKeyExpires                            = "Expires"
+	ConditionKeyKey                                = "key"
+	ConditionKeySuccessActionRedirect              = "success_action_redirect"
+	ConditionKeyRedirect                           = "redirect"
+	ConditionKeySuccessActionStatus                = "success_action_status"
+
+	// For AWS Signature Version 4, the value is AWS4-HMAC-SHA256.
+	ConditionKeyAMZAlgorithm = "x-amz-algorithm"
+
+	// It is a string of the following form:
+	// <your-access-key-id>/<date>/<aws-region>/<aws-service>/aws4_request
+	ConditionKeyAMZCredential = "x-amz-credential"
+
+	// The date value specified in the ISO8601 formatted string.
+	ConditionKeyAMZDate = "x-amz-date"
+
+	// Amazon DevPay security token.
+	ConditionKeyAMZSecurityToken = "x-amz-security-token"
+)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -34,10 +34,13 @@ const (
 	ConditionMatchRange
 )
 
-// Condition elements supported by default. See AWS docs for rules when using
-// each.
+// Condition elements supported by default.
+//
 // If you need to use x-amz-meta-* or x-amz-* condition elements you can pass
 // those as strings to SetCondition.
+//
+// AWS Docs have more information when using each:
+// http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html#sigv4-PolicyConditions
 const (
 	ConditionACL                   string = "acl"
 	ConditionBucket                       = "bucket"
@@ -57,7 +60,7 @@ const (
 	ConditionAMZSecurityToken             = "x-amz-security-token"
 )
 
-// Policy represents an AWS POST policy.
+// Policy represents an AWS S3 POST policy.
 // More specifics on what a policy should include can be found here:
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
 type Policy struct {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 )
@@ -54,13 +53,8 @@ func TestPolicy(t *testing.T) {
 		ConditionMatchExact,
 	)
 
-	b, err := json.Marshal(p)
-	if err != nil {
-		t.Fatal("Issue marshaling policy json", err)
-	}
-
-	if string(b) != policyDocWants {
-		t.Errorf("wanted: \n %s \n got: \n %s \n", policyDocWants, string(b))
+	if p.String() != policyDocWants {
+		t.Errorf("wanted: \n %s \n got: \n %s \n", policyDocWants, p)
 	}
 }
 

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -10,46 +10,46 @@ func TestPolicy(t *testing.T) {
 	p := Policy{
 		Expiration: time.Date(2015, 12, 30, 12, 0, 0, 0, time.UTC),
 	}
-	p.SetCondition(ConditionKeyBucket, "sigv4examplebucket", ConditionMatchExact)
-	p.SetCondition(ConditionKeyKey, "user/user1/", ConditionMatchStartsWith)
-	p.SetCondition(ConditionKeyACL, "public-read", ConditionMatchExact)
+	p.SetCondition(ConditionBucket, "sigv4examplebucket", ConditionMatchExact)
+	p.SetCondition(ConditionKey, "user/user1/", ConditionMatchStartsWith)
+	p.SetCondition(ConditionACL, "public-read", ConditionMatchExact)
 	p.SetCondition(
-		ConditionKeySuccessActionRedirect,
+		ConditionSuccessActionRedirect,
 		"http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html",
 		ConditionMatchExact,
 	)
 	p.SetCondition(
-		ConditionKeyContentType,
+		ConditionContentType,
 		"image/",
 		ConditionMatchStartsWith,
 	)
 	p.SetCondition(
-		ConditionKey("x-amz-meta-uuid"),
+		"x-amz-meta-uuid",
 		"14365123651274",
 		ConditionMatchExact,
 	)
 	p.SetCondition(
-		ConditionKey("x-amz-server-side-encryption"),
+		"x-amz-server-side-encryption",
 		"AES256",
 		ConditionMatchExact,
 	)
 	p.SetCondition(
-		ConditionKey("x-amz-meta-tag"),
+		"x-amz-meta-tag",
 		"",
 		ConditionMatchStartsWith,
 	)
 	p.SetCondition(
-		ConditionKeyAMZCredential,
+		ConditionAMZCredential,
 		"AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request",
 		ConditionMatchExact,
 	)
 	p.SetCondition(
-		ConditionKeyAMZAlgorithm,
+		ConditionAMZAlgorithm,
 		AWSV4SignatureAlgorithm,
 		ConditionMatchExact,
 	)
 	p.SetCondition(
-		ConditionKeyAMZDate,
+		ConditionAMZDate,
 		"20151229T000000Z",
 		ConditionMatchExact,
 	)

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestPolicy(t *testing.T) {
+	p := Policy{
+		Expiration: time.Date(2015, 12, 30, 12, 0, 0, 0, time.UTC),
+	}
+	p.SetCondition(ConditionKeyBucket, "sigv4examplebucket", ConditionMatchExact)
+	p.SetCondition(ConditionKeyKey, "user/user1/", ConditionMatchStartsWith)
+	p.SetCondition(ConditionKeyACL, "public-read", ConditionMatchExact)
+	p.SetCondition(
+		ConditionKeySuccessActionRedirect,
+		"http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html",
+		ConditionMatchExact,
+	)
+	p.SetCondition(
+		ConditionKeyContentType,
+		"image/",
+		ConditionMatchStartsWith,
+	)
+	p.SetCondition(
+		ConditionKey("x-amz-meta-uuid"),
+		"14365123651274",
+		ConditionMatchExact,
+	)
+	p.SetCondition(
+		ConditionKey("x-amz-server-side-encryption"),
+		"AES256",
+		ConditionMatchExact,
+	)
+	p.SetCondition(
+		ConditionKey("x-amz-meta-tag"),
+		"",
+		ConditionMatchStartsWith,
+	)
+	p.SetCondition(
+		ConditionKeyAMZCredential,
+		"AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request",
+		ConditionMatchExact,
+	)
+	p.SetCondition(
+		ConditionKeyAMZAlgorithm,
+		AWSV4SignatureAlgorithm,
+		ConditionMatchExact,
+	)
+	p.SetCondition(
+		ConditionKeyAMZDate,
+		"20151229T000000Z",
+		ConditionMatchExact,
+	)
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal("Issue marshaling policy json", err)
+	}
+
+	if string(b) != policyDocWants {
+		t.Errorf("wanted: \n %s \n got: \n %s \n", policyDocWants, string(b))
+	}
+}
+
+const policyDocWants = `{"expiration":"2015-12-30T12:00:00.000Z","conditions":[{"bucket":"sigv4examplebucket"},["starts-with","$key","user/user1/"],{"acl":"public-read"},{"success_action_redirect":"http://sigv4examplebucket.s3.amazonaws.com/successful_upload.html"},["starts-with","$Content-Type","image/"],{"x-amz-meta-uuid":"14365123651274"},{"x-amz-server-side-encryption":"AES256"},["starts-with","$x-amz-meta-tag",""],{"x-amz-credential":"AKIAIOSFODNN7EXAMPLE/20151229/us-east-1/s3/aws4_request"},{"x-amz-algorithm":"AWS4-HMAC-SHA256"},{"x-amz-date":"20151229T000000Z"}]}`

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -53,8 +54,13 @@ func TestPolicy(t *testing.T) {
 		ConditionMatchExact,
 	)
 
-	if p.String() != policyDocWants {
-		t.Errorf("wanted: \n %s \n got: \n %s \n", policyDocWants, p)
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != policyDocWants {
+		t.Errorf("wanted: \n %s \n got: \n %s \n", policyDocWants, string(b))
 	}
 }
 

--- a/s3upload.go
+++ b/s3upload.go
@@ -36,9 +36,6 @@ func New(region, secret string) *S3Upload {
 // reimplement now with a function that returns the exact date we want.
 var now = time.Now
 
-// store this for less typing in Sign
-var b64 = base64.StdEncoding
-
 // Sign takes a POST policy and outputs the signed version of the policy as
 // well as a signature to include in the POST form.
 //
@@ -47,31 +44,44 @@ var b64 = base64.StdEncoding
 //
 // Returns the base64-encoded policy and the hex-encoded and signed policy.
 func (s *S3Upload) Sign(policy []byte) (string, string) {
-	s256 := sha256.New
-
 	// policy encoded in base64 (String to Sign)
-	stringToSign := make([]byte, b64.EncodedLen(len(policy)))
-	b64.Encode(stringToSign, policy)
+	stringToSign := make([]byte, base64.StdEncoding.EncodedLen(len(policy)))
+	base64.StdEncoding.Encode(stringToSign, policy)
 
 	// DateKey = HMACSHA256("AWS4"+awsSecret, "yyyymmdd")
-	dk := hmac.New(s256, []byte("AWS4"+s.awsSecret))
-	dk.Write([]byte(now().UTC().Format("20060102")))
+	dk := hmac.New(sha256.New, []byte("AWS4"+s.awsSecret))
+	_, err := dk.Write([]byte(now().UTC().Format("20060102")))
+	if err != nil {
+		return "", ""
+	}
 
 	// DateRegionKey = HMACSHA256(DateKey, awsRegion)
-	drk := hmac.New(s256, dk.Sum(nil))
-	drk.Write([]byte(s.awsRegion))
+	drk := hmac.New(sha256.New, dk.Sum(nil))
+	_, err = drk.Write([]byte(s.awsRegion))
+	if err != nil {
+		return "", ""
+	}
 
 	// DateRegionServiceKey = HMACSHA256(DateRegionKey, "s3")
-	drsk := hmac.New(s256, drk.Sum(nil))
-	drsk.Write([]byte("s3"))
+	drsk := hmac.New(sha256.New, drk.Sum(nil))
+	_, err = drsk.Write([]byte("s3"))
+	if err != nil {
+		return "", ""
+	}
 
 	// SigningKey = HMACSHA256(DateRegionServiceKey, "aws4_request")
-	signingKey := hmac.New(s256, drsk.Sum(nil))
-	signingKey.Write([]byte("aws4_request"))
+	signingKey := hmac.New(sha256.New, drsk.Sum(nil))
+	_, err = signingKey.Write([]byte("aws4_request"))
+	if err != nil {
+		return "", ""
+	}
 
 	// Signature = HMACSHA256(SigningKey, StringToSign)
-	signature := hmac.New(s256, signingKey.Sum(nil))
-	signature.Write([]byte(stringToSign))
+	signature := hmac.New(sha256.New, signingKey.Sum(nil))
+	_, err = signature.Write([]byte(stringToSign))
+	if err != nil {
+		return "", ""
+	}
 
 	// encode signature using hex encoding
 	encsig := make([]byte, hex.EncodedLen(signature.Size()))

--- a/s3upload.go
+++ b/s3upload.go
@@ -43,6 +43,7 @@ var now = time.Now
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
 //
 // Returns the base64-encoded policy and the hex-encoded and signed policy.
+// If an error occurs two empty strings will be returned.
 func (s *S3Upload) Sign(policy []byte) (string, string) {
 	// policy encoded in base64 (String to Sign)
 	stringToSign := make([]byte, base64.StdEncoding.EncodedLen(len(policy)))

--- a/s3upload.go
+++ b/s3upload.go
@@ -32,24 +32,18 @@ func New(region, secret string) *S3Upload {
 	return s
 }
 
-// Signed holds both the base64 encoded policy document and the hex encoded
-// signature to be sent off with a POST form.
-type Signed struct {
-	Policy    string
-	Signature string
-}
-
 // We need to be able to fake the current time in tests. This allows us to
 // reimplement now with a function that returns the exact date we want.
 var now = time.Now
 
-// TODO: should this simply return (policy, signature string)?
 // Sign takes a POST policy and outputs the signed version of the policy as
 // well as a signature to include in the POST form.
 //
 // Signature is created by the calculation process here:
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
-func (s *S3Upload) Sign(policy []byte) Signed {
+//
+// Returns the base64-encoded policy and the hex-encoded, and signed, policy.
+func (s *S3Upload) Sign(policy []byte) (string, string) {
 	b64 := base64.StdEncoding
 	s256 := sha256.New
 
@@ -81,10 +75,5 @@ func (s *S3Upload) Sign(policy []byte) Signed {
 	encsig := make([]byte, hex.EncodedLen(signature.Size()))
 	hex.Encode(encsig, signature.Sum(nil))
 
-	d := Signed{
-		Policy:    string(stringToSign),
-		Signature: string(encsig),
-	}
-
-	return d
+	return string(stringToSign), string(encsig)
 }

--- a/s3upload.go
+++ b/s3upload.go
@@ -36,15 +36,17 @@ func New(region, secret string) *S3Upload {
 // reimplement now with a function that returns the exact date we want.
 var now = time.Now
 
+// store this for less typing in Sign
+var b64 = base64.StdEncoding
+
 // Sign takes a POST policy and outputs the signed version of the policy as
 // well as a signature to include in the POST form.
 //
 // Signature is created by the calculation process here:
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
 //
-// Returns the base64-encoded policy and the hex-encoded, and signed, policy.
+// Returns the base64-encoded policy and the hex-encoded and signed policy.
 func (s *S3Upload) Sign(policy []byte) (string, string) {
-	b64 := base64.StdEncoding
 	s256 := sha256.New
 
 	// policy encoded in base64 (String to Sign)

--- a/s3upload.go
+++ b/s3upload.go
@@ -43,6 +43,7 @@ type Signed struct {
 // reimplement now with a function that returns the exact date we want.
 var now = time.Now
 
+// TODO: should this simply return (policy, signature string)?
 // Sign takes a POST policy and outputs the signed version of the policy as
 // well as a signature to include in the POST form.
 //

--- a/s3upload_test.go
+++ b/s3upload_test.go
@@ -17,15 +17,15 @@ func TestSign(t *testing.T) {
 		return time.Date(2015, 12, 29, 0, 0, 0, 0, time.UTC)
 	}
 
-	signed := s.Sign([]byte(policy))
+	policy, signature := s.Sign([]byte(policy))
 
 	now = time.Now
 
-	if signed.Policy != encPolicy {
-		t.Errorf("Incorrect signed policy. Expected: %s\nActual: %s\n", signed.Policy, encPolicy)
+	if policy != encPolicy {
+		t.Errorf("Incorrect signed policy. Expected: %s\nActual: %s\n", policy, encPolicy)
 	}
-	if signed.Signature != encSignature {
-		t.Errorf("Incorrect encoded signature. Expected: %s\nActual: %s\n", signed.Signature, encSignature)
+	if signature != encSignature {
+		t.Errorf("Incorrect encoded signature. Expected: %s\nActual: %s\n", signature, encSignature)
 	}
 }
 


### PR DESCRIPTION
- Change signature of `s3upload.Sign()` to simply return two strings since it'll never have a reason to return anything else
- Add `policy` package to assist in generating POST policies
- Add an example to document use of the `policy` package
- Update docs and readmes
- Add go1.7 to travis